### PR TITLE
allow marathon mesos to set REMOTE_HOST

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -16,6 +16,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+if [ ! -z "$MESOS_TASK_ID" ]; then
+  REMOTE_HOST="http://${HOST}:${PORT_5555}"
+fi
+
 REMOTE_HOST_PARAM=""
 if [ ! -z "$REMOTE_HOST" ]; then
   echo "REMOTE_HOST variable is set, appending -remoteHost"


### PR DESCRIPTION
- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
